### PR TITLE
Fix duplicate marker name check logic for MarkersState.addMarker

### DIFF
--- a/lib/src/state/markers.dart
+++ b/lib/src/state/markers.dart
@@ -28,19 +28,16 @@ class MarkersState {
   /// The markers present on the map and their names
   Map<String, Marker> get namedMarkers => _namedMarkers;
 
-  /// Adds a marker to the map. Does nothing if a marker with the same name
-  /// already exists.
+  /// Adds a marker to the map. Replaces the marker if a marker with the same
+  /// name already exists.
   void addMarker({required String name, required Marker marker}) {
     try {
       // If the marker with the same name already exists, do nothing
-      if (_namedMarkers.containsKey(name)) return;
-
-      final markerAt = _markerAt(marker, name);
-
-      if (markerAt == null) {
-        _markers.add(marker);
+      if (_namedMarkers.containsKey(name)) {
+        final markerAt = _markerAt(name);
+        _markers[markerAt!] = marker;
       } else {
-        _markers[markerAt] = marker;
+        _markers.add(marker);
       }
     } catch (e) {
       throw MarkerException("Can not build marker $name for add: $e");
@@ -60,7 +57,7 @@ class MarkersState {
 
       if (marker == null) return;
 
-      final removeAt = _markerAt(marker, name);
+      final removeAt = _markerAt(name);
       if (removeAt == null) {
         throw MarkerException("Can not find marker $name for removal");
       }
@@ -122,7 +119,7 @@ class MarkersState {
     return feature;
   }
 
-  int? _markerAt(Marker marker, String name) {
+  int? _markerAt(String name) {
     final markerAt = _namedMarkers[name];
 
     if (markerAt == null) {

--- a/lib/src/state/markers.dart
+++ b/lib/src/state/markers.dart
@@ -28,12 +28,12 @@ class MarkersState {
   /// The markers present on the map and their names
   Map<String, Marker> get namedMarkers => _namedMarkers;
 
-  /// Add a marker on the map
+  /// Adds a marker to the map. Does nothing if a marker with the same name
+  /// already exists.
   void addMarker({required String name, required Marker marker}) {
     try {
-      final marker = _namedMarkers[name];
-
-      if (marker == null) return;
+      // If the marker with the same name already exists, do nothing
+      if (_namedMarkers.containsKey(name)) return;
 
       final markerAt = _markerAt(marker, name);
 

--- a/lib/src/state/markers.dart
+++ b/lib/src/state/markers.dart
@@ -32,7 +32,7 @@ class MarkersState {
   /// name already exists.
   void addMarker({required String name, required Marker marker}) {
     try {
-      // If the marker with the same name already exists, do nothing
+      // If the marker with the same name already exists, replace it
       if (_namedMarkers.containsKey(name)) {
         final markerAt = _markerAt(name);
         _markers[markerAt!] = marker;


### PR DESCRIPTION
Issue described here: https://github.com/TesteurManiak/map_controller_plus/issues/13

Fixed logic here by doing a `containsKey` check on `_namedMarkers` to determine if we need to replace vs add the marker.

I also removed the `marker` parameter from `_markerAt` which was not being used in the method at all.

Tested this by ensuring that icons were being properly added and removed by calling `addMarker` and `removeMarker`